### PR TITLE
Refactor rc script to use prestart/poststart, and ensure shutdown

### DIFF
--- a/priv/templates/freebsd.pkg/rc.eex
+++ b/priv/templates/freebsd.pkg/rc.eex
@@ -2,40 +2,57 @@
 #
 # PROVIDE: <%= @pkg_name %>
 # REQUIRE: DAEMON
+# KEYWORD: shutdown
 
 . /etc/rc.subr
 
 name=<%= @pkg_name %>
 rcvar=${name}_enable
+
+load_rc_config $name
+
 pidfile="/var/run/${name}.pid"
 procname="<%= FreeBSD.pkg_prefix() %>/<%= @beam_path %>"
 confdir="<%= @conf_dir %>"
 logfile="/var/log/${name}.log"
 
-: ${<%= @pkg_name %>_env_file:=<%= @conf_dir %>/<%= @pkg_name %>.env}
+: ${<%= @pkg_name %>_env_file:="<%= @conf_dir %>/<%= @pkg_name %>.env"}
 
 command="<%= FreeBSD.pkg_prefix() %>/<%= @bin_path %>"
+start_precmd="${name}_prestart"
+start_postcmd="${name}_poststart"
+start_cmd="${name}_start"
+remote_cmd="${name}_remote"
 extra_commands="remote"
-start_cmd=<%= @pkg_name %>_start
-remote_cmd=<%= @pkg_name %>_remote
+
+: ${<%= @conf_dir_var %>_CONF_DIR:="${confdir}"}
+: ${RELEASE_TMP:="/var/run/${name}"}
+: ${ERL_CRASH_DUMP:="${RELEASE_TMP}/${name}_erl_crash.dump"}
+
+<%= @pkg_name %>_prestart()
+{
+  if [ ! -d "${RELEASE_TMP}" ]; then
+    echo "Creating ${RELEASE_TMP}."
+    mkdir $RELEASE_TMP
+    chmod 740 $RELEASE_TMP
+<%= if @pkg_user do %>
+    echo "Setting ${RELEASE_TMP} owner to <%= @pkg_user %>."
+    chown -R <%= @pkg_user %>:<%= @pkg_user %> $RELEASE_TMP
+<% end %>
+  fi
+}
+
+<%= @pkg_name %>_poststart()
+{
+  pid="$(cat ${pidfile})"
+  echo "Service ${name} started as pid ${pid}."
+}
 
 <%= @pkg_name %>_start()
 {
-  : ${<%= @conf_dir_var %>_CONF_DIR:=$confdir}
-  export <%= @conf_dir_var %>_CONF_DIR
-  : ${RELEASE_TMP:=/var/run/${name}}
-  export RELEASE_TMP
-  : ${ERL_CRASH_DUMP:=${RELEASE_TMP}/${name}_erl_crash.dump}
-  export ERL_CRASH_DUMP
+  export <%= @conf_dir_var %>_CONF_DIR RELEASE_TMP ERL_CRASH_DUMP
 
-  if [ ! -d "${RELEASE_TMP}" ]; then
-    mkdir $RELEASE_TMP
-    chmod 740 $RELEASE_TMP
-  fi
-  <%= if @pkg_user do %>
-  echo "Setting ${RELEASE_TMP} owned by <%= @pkg_user %>."
-  chown -R <%= @pkg_user %>:<%= @pkg_user %> $RELEASE_TMP
-  <% end %>
+  rm -f ${pidfile}
   daemon -t $name -p $pidfile -f -H -o $logfile <%= @daemon_flags %> $command start
 }
 
@@ -45,5 +62,4 @@ remote_cmd=<%= @pkg_name %>_remote
   $command remote
 }
 
-load_rc_config $name
 run_rc_command "$@"


### PR DESCRIPTION
Reading through https://docs.freebsd.org/en/articles/rc-scripting/ and https://github.com/freebsd/freebsd-ports/blob/main/net/rabbitmq/files/rabbitmq.in, it seemed like this could be reorganized to make things a little more clear.